### PR TITLE
Add map function

### DIFF
--- a/src/psq.ml
+++ b/src/psq.ml
@@ -42,6 +42,7 @@ module type S = sig
   val to_priority_seq : t -> (k * p) Seq.t
   val filter : (k -> p -> bool) -> t -> t
   val partition : (k -> p -> bool) -> t -> t * t
+  val map : (k -> p -> p) -> t -> t
   val pp : ?sep:(unit fmt) -> (k * p) fmt -> t fmt
   val pp_dump : k fmt -> p fmt -> t fmt
   val depth : t -> int
@@ -269,6 +270,13 @@ struct
     fun pf -> function N -> N | T (kp, sk, t) -> go pf kp sk t
 
   let partition pf t = filter pf t, filter (fun k p -> not (pf k p)) t
+
+  let map =
+    let rec go f kp1 sk1 = function
+      Lf -> let k = fst kp1 in sg (k, f k (snd kp1))
+    | NdL (kp2, t1, sk2, t2, _) -> go f kp2 sk2 t1 >< go f kp1 sk1 t2
+    | NdR (kp2, t1, sk2, t2, _) -> go f kp1 sk2 t1 >< go f kp2 sk1 t2 in
+    fun f -> function N -> N | T (kp, sk, t) -> go f kp sk t
 
   let split_at =
     let rec go k0 pk sk = function

--- a/src/psq.mli
+++ b/src/psq.mli
@@ -190,6 +190,9 @@ module type S = sig
   (** [partition p t] is [(filter p t, filter np t)] where [np] is the negation
       of [p]. *)
 
+  val map : (k -> p -> p) -> t -> t
+  (** [map f t] is [f] applied to all the bindings in [t]. *)
+
   (** {1 Pretty-printing} *)
 
   open Format


### PR DESCRIPTION
Hi. Thanks for making this package, I have been relying heavily on it for a project I've been working on. The lack of a `map` function and having to simulate it however represented a bottleneck so I added an ability to map over the bindings, which seems conspicuously missing anyway as both `fold` and `filter` are there.

I am not completely familiar with the data structure so I just modeled it after `filter`. In any case, it behaves as expected.